### PR TITLE
set global_remote_state to fix bug with remote_state_consumer_ids

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -15,6 +15,7 @@ resource "tfe_workspace" "free-cloud9" {
   project_id                = tfe_project.main.id
   execution_mode            = "local"
   remote_state_consumer_ids = [tfe_workspace.free-infra[0].id]
+  global_remote_state = false
 }
 
 resource "tfe_workspace" "free-infra" {


### PR DESCRIPTION
when setting explicit workspace consumer ids, global_remote_state should be set to 'false'